### PR TITLE
chore(lint-staged): remove extra `git add` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "lint-staged": {
     "*.{js,vue}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Hi! Thanks for this great tool!

When browsing across the `lint-staged` configuration, I noticed that you are using deprecated `git add` command.

see: https://github.com/okonet/lint-staged#v10

Hope you'll find this useful.